### PR TITLE
Adapt deployer to read secrets from vault with KV V2

### DIFF
--- a/ecs_deployer/vault.py
+++ b/ecs_deployer/vault.py
@@ -4,13 +4,13 @@ import hvac
 def get_configuration_vars(host: str, token: str, path: str) -> list:
     client = hvac.Client(url=host, token=token)
     response = client.read(path)
-    resp_data = response.get('data')
+    data = response.get('data')
 
     # Compatible KV V1 and KV V2
-    if resp_data and 'data' in resp_data and 'metadata' in resp_data:
-        env_vars = resp_data.get('data')
+    if data and len(data) == 2 and 'data' in data and 'metadata' in data:
+        env_vars = data.get('data')
     else:
-        env_vars = resp_data
+        env_vars = data
 
 
     return [{"name": k, "value": v} for k, v in env_vars.items()]


### PR DESCRIPTION
The result of read secret in KV V2 have a different structure.

KV V1 Response
```
{
  "request_id": "3c9e7bdc-c585-85ae-c412-6c96c17bb24e",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 2764800,
  "data": {
    "password": "1234567890987654321"
  },
  "wrap_info": null,
  "warnings": null,
  "auth": null
}
```

KV V2 Response
```
{
  "request_id": "e9204dc0-797e-5c79-297e-e76e008b6e8f",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 0,
  "data": {
    "data": {
      "password": "1234567890987654321"
    },
    "metadata": {
      "created_time": "2019-07-02T13:30:47.649730672Z",
      "deletion_time": "",
      "destroyed": false,
      "version": 1
    }
  },
  "wrap_info": null,
  "warnings": null,
  "auth": null
} 
```

The version KV V2 return the `data` dictionary with the key/vaules returned in KV V1 nested in a dictionary with a `data`key.

KV V1 data result: **"data":  {"password": "1234567890987654321"}**

KV V2 data result: "data":  { **"data":  {"password": "1234567890987654321"}**, "metadata":  {...}}
